### PR TITLE
Fix import consistency in code examples

### DIFF
--- a/docs/TECHNICAL_VISION.md
+++ b/docs/TECHNICAL_VISION.md
@@ -168,10 +168,10 @@ if __name__ == "__main__":
 #### Unified Configuration (from 01_config.ipynb)
 ```python
 #| export
+import os
 from dataclasses import dataclass, field
 from typing import Dict, List, Optional, Any
 from datetime import timedelta
-import os
 from pathlib import Path
 
 @dataclass
@@ -267,6 +267,8 @@ assert enterprise_config.enforce_2fa == True
 ```python
 #| export
 import logging
+import os
+from typing import Dict, List, Optional, Any
 from fasthtml.common import *
 from .middleware import setup_middleware
 from .database import setup_database
@@ -387,6 +389,7 @@ Each section includes examples and tests demonstrating the functionality.
 #| export
 import bcrypt
 import secrets
+import os
 from datetime import datetime, timedelta
 from typing import Optional, Dict, Any
 from dataclasses import dataclass
@@ -527,10 +530,11 @@ Examples show how to customize for different use cases.
 """
 
 #| export
+import os
+import json
 from typing import List, Dict, Any, Optional
 from datetime import datetime, timedelta
 from fasthtml.common import *
-import json
 
 class AdminDashboard:
     """
@@ -718,8 +722,9 @@ Example from a UI components notebook:
 """Let's create a reusable data table component"""
 
 #| export
-from fasthtml.common import *
+import os
 from typing import List, Dict, Any, Optional, Callable
+from fasthtml.common import *
 
 def DataTable(
     columns: List[str], 
@@ -905,6 +910,8 @@ launch-kit deploy  # Deploy wizard
 The combination of nbdev and FastHTML creates powerful development patterns:
 ```python
 #| export
+import os
+from typing import Dict, List, Optional, Any
 from fasthtml.common import *
 from functools import wraps
 from launch_kit import get_current_user, get_team_member
@@ -1071,9 +1078,11 @@ form = AuthForm(
 Database schema and migrations are developed in notebooks with visual feedback:
 ```python
 #| export
-from launch_kit.db import Migration, Schema
-from datetime import datetime
+import os
 import sqlite3
+from typing import Dict, List, Optional, Any
+from datetime import datetime
+from launch_kit.db import Migration, Schema
 
 class AddTeamsTable(Migration):
     """Add teams table for multi-tenant support"""
@@ -1204,11 +1213,12 @@ All test utilities are demonstrated with examples that also serve as tests thems
 """
 
 #| export
+import os
 import asyncio
-from typing import Dict, Any, Optional
-from datetime import datetime
 import sqlite3
 import tempfile
+from typing import Dict, Any, Optional
+from datetime import datetime
 from contextlib import contextmanager
 
 class SaaSTestCase:
@@ -1469,8 +1479,8 @@ from launch_kit import ProductionConfig
 
 config = ProductionConfig(
     # Auto-configures from environment
-    database_url=env("DATABASE_URL"),
-    redis_url=env("REDIS_URL"),
+    database_url=os.environ.get("DATABASE_URL"),
+    redis_url=os.environ.get("REDIS_URL"),
     
     # Production defaults
     debug=False,
@@ -1478,7 +1488,7 @@ config = ProductionConfig(
     force_https=True,
     
     # Monitoring
-    sentry_dsn=env("SENTRY_DSN"),
+    sentry_dsn=os.environ.get("SENTRY_DSN"),
     metrics_enabled=True,
 )
 ```


### PR DESCRIPTION
Fixes #3

This PR addresses import consistency issues in the documentation code examples:

- ✅ Added missing `import os` statements where needed
- ✅ Ensured consistent typing imports: `from typing import Dict, List, Optional, Any`
- ✅ Fixed undefined `env()` function references to use `os.environ.get()`
- ✅ Reorganized imports for consistency throughout the file

All code examples in docs/TECHNICAL_VISION.md now have proper and consistent imports.

Generated with [Claude Code](https://claude.ai/code)