### PR TITLE
Updated claude memory with repo location

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,3 +93,7 @@ This project uses MonsterUI as the default UI framework. When developing:
        Form(FormField(Label("Email"), Input(type="email")))
    )
    ```
+
+## Repository Information
+
+- GitHub Repository: https://github.com/LotsOfOrg/launch-kit


### PR DESCRIPTION
This pull request updates the `CLAUDE.md` documentation by adding a new section to provide repository information.

* [`CLAUDE.md`](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7R96-R99): Added a "Repository Information" section with a link to the GitHub repository for better accessibility.